### PR TITLE
fix: warn player when tool durability drops below threshold

### DIFF
--- a/core/src/main/java/com/rappytv/toolwarn/listener/GameTickListener.java
+++ b/core/src/main/java/com/rappytv/toolwarn/listener/GameTickListener.java
@@ -53,7 +53,7 @@ public class GameTickListener {
             if(tool.getType() != type) continue;
             int itemWarnInt = (tool.getWarnAt() * itemStack.getMaximumDamage()) / 100;
 
-            if(itemUsedInt == itemWarnInt) {
+            if(itemUsedInt <= itemWarnInt) {
                 if(!warns.contains(itemStack)) {
                     if(tool.openChat()) Laby.labyAPI().minecraft().openChat("");
                     Laby.references().chatExecutor().displayClientMessage(


### PR DESCRIPTION
Changed equality check (==) to less-or-equal (<=) in durability warning logic.
Prevents missed warnings when tools lose multiple durability points in one action,
e.g. when using Timber or other multi-hit mechanics.